### PR TITLE
Merge coverage from different runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,13 +175,13 @@ jobs:
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: |
           ctest --output-on-failure -C ${{matrix.build_type}}
-          gcovr -j ${{env.nproc}} --delete --root ../ --print-summary --xml-pretty --xml coverage.xml . --gcov-executable '${{ matrix.gcov_executable }}'
+          gcovr -j ${{env.nproc}} --delete --root ../ --print-summary --xml-pretty --xml ${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}-coverage.xml . --gcov-executable '${{ matrix.gcov_executable }}'
 
       - name: Windows - Test and coverage
         if: runner.os == 'Windows'
         working-directory: ./build
         run: |
-          OpenCppCoverage.exe --export_type cobertura:coverage.xml --cover_children -- ctest -C ${{matrix.build_type}}
+          OpenCppCoverage.exe --export_type cobertura:${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}-coverage.xml --cover_children -- ctest -C ${{matrix.build_type}}
 
       - name: Archive production artifacts
         if: ${{ failure() }}
@@ -212,4 +212,4 @@ jobs:
         with:
           flags: ${{ runner.os }}
           name: ${{ runner.os }}-coverage
-          files: ./build/coverage.xml
+          files: ./build/${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}-coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,13 +184,14 @@ jobs:
           OpenCppCoverage.exe --export_type cobertura:${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}-coverage.xml --cover_children -- ctest -C ${{matrix.build_type}}
 
       - name: Archive production artifacts
-        if: ${{ failure() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: artifacts-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}-${{matrix.packaging_maintainer_mode}}
 
           path: |
             build/test/*.xml
+            */*-coverage.xml
           retention-days: 2
 
       - name: CPack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,6 @@ jobs:
       - name: Publish to codecov
         uses: codecov/codecov-action@v3
         with:
-          flags: ${{ runner.os }}
-          name: ${{ runner.os }}-coverage
+          flags: ${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}
+          name: ${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}-coverage
           files: ./build/${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}-coverage.xml


### PR DESCRIPTION
By giving  different filename for each runner, the coverage of all of them should be merged instead of overwritten by the last run.